### PR TITLE
Dynamic Copyright Year

### DIFF
--- a/BucStop/Views/Shared/_Layout.cshtml
+++ b/BucStop/Views/Shared/_Layout.cshtml
@@ -60,7 +60,7 @@
     <!-- This block handles the footer, which includes the version number for the project. -->
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2023 - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/chrisseals98/BOBBY/releases/tag/v2.0.0" style="color:#C6AA76;">Version: 2.0.0</a><a> - </a>
+            &copy; <script>document.write(new Date().getFullYear())</script> - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/chrisseals98/BOBBY/releases/tag/v2.0.0" style="color:#C6AA76;">Version: 2.0.0</a><a> - </a>
 
         </div>
     </footer>


### PR DESCRIPTION
The copyright year should automatically update to the correct year.
Instead of a static "2023", I added a javascript method that retrieves your local machine's date.