### PR TITLE
version number at bottom of page update

### DIFF
--- a/BucStop/Views/Shared/_Layout.cshtml
+++ b/BucStop/Views/Shared/_Layout.cshtml
@@ -67,7 +67,7 @@
     <!-- This block handles the footer, which includes the version number for the project. -->
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; <script>document.write(new Date().getFullYear())</script> - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/TheOnlyTeam4350-001" style="color:#C6AA76;">Version: 3.0.5</a><a> - Current Visit Count: @(Context.Items["VisitCount"] ?? 0)</a>
+            &copy; <script>document.write(new Date().getFullYear())</script> - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/TheOnlyTeam4350-001" style="color:#C6AA76;">Version: 3.0.8</a><a> - Current Visit Count: @(Context.Items["VisitCount"] ?? 0)</a>
 
         </div>
     </footer>


### PR DESCRIPTION
Small fix to the hardcoded version number at the bottom of the page